### PR TITLE
Fix equation formatting in freq-modeling.qmd

### DIFF
--- a/freq-modeling.qmd
+++ b/freq-modeling.qmd
@@ -125,7 +125,7 @@ and assume that the system starts from zero-initial state and take the LT of bot
 $$
 a_n s^n Y(s) + a_{n-1} s^{n-1} Y(s) + \cdots + a_0 Y(s)
 =
-b_m s^m U(s) + b_{m-1} s^{m-1} U(s) + \cdots + b_m U(s).
+b_m s^m U(s) + b_{m-1} s^{m-1} U(s) + \cdots + b_0 U(s).
 $$
 Rearranging terms, we get
 $$


### PR DESCRIPTION
Corrected the equation formatting in the document.

The last element should be b0 and not bm